### PR TITLE
Added docs for X11 key remapping

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -237,10 +237,14 @@ To remove an existing keyboard shortcut, you can use `keymap.unbind()`.
     ![Screenshot showing the keybind changer][13]{ loading=lazy }
 
 
-!!! tip "Keyboard mapping on X11"
-    Lite XL interprets keypresses based on their physical location, regardless of the keyboard layout.
-    Tools such as `xmodmap` will therefore have no effect; instead you'll have to modify your keymap in Lite XL directly.
-    For example, to remap CapsLock to Control add this to your user module:
+!!! tip
+    On X11, Lite XL interprets keypresses based on their physical location,
+    regardless of the keyboard layout set in your DE settings.
+    Tools such as `xmodmap` will therefore have no effect; instead you'll have to modify your keymap
+    in Lite XL directly.
+
+    For example, to remap ++caps-lock++ to ++ctrl++, add this to your user module:
+
     ```lua
     local modkeys = require("core.modkeys-" .. (PLATFORM == "Mac OS X" and "macos" or "generic"))
     modkeys.map["capslock"] = "ctrl" -- this maps capslock to ctrl

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -236,14 +236,17 @@ To remove an existing keyboard shortcut, you can use `keymap.unbind()`.
     Afterwards, press the "Save" button to save the changes.
     ![Screenshot showing the keybind changer][13]{ loading=lazy }
 
-### X11: Remapping CapsLock and Ctrl
 
-Lite-XL reads scancodes from SDL so it's not aware of any remapping done via X11 (e.g. via `xkbset` or GNOME settings).
-The tool `setscancodes` can be used as a workaround. A common use case is to map CapsLock to an additional Ctrl:
-
-```bash
-sudo setkeycodes 3a 29
-```
+!!! tip "Keyboard mapping on X11"
+    Lite XL interprets keypresses based on their physical location, regardless of the keyboard layout.
+    Tools such as `xmodmap` with therefore have no effect; instead you'll have to modify your keymap in Lite XL directly.
+    For example, to remap CapsLock to Control add this to your user module:
+    ```lua
+    local modkeys = require("core.modkeys-" .. (PLATFORM == "Mac OS X" and "macos" or "generic"))
+    modkeys.map["capslock"] = "ctrl" -- this maps capslock to ctrl
+    table.insert(modkeys.keys, "capslock") -- this enables capslock as modifier
+    modkeys.map["left ctrl"] = "capslock" -- this maps left ctrl to capslock
+    ```
 
 ## Themes
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -239,7 +239,7 @@ To remove an existing keyboard shortcut, you can use `keymap.unbind()`.
 
 !!! tip "Keyboard mapping on X11"
     Lite XL interprets keypresses based on their physical location, regardless of the keyboard layout.
-    Tools such as `xmodmap` with therefore have no effect; instead you'll have to modify your keymap in Lite XL directly.
+    Tools such as `xmodmap` will therefore have no effect; instead you'll have to modify your keymap in Lite XL directly.
     For example, to remap CapsLock to Control add this to your user module:
     ```lua
     local modkeys = require("core.modkeys-" .. (PLATFORM == "Mac OS X" and "macos" or "generic"))

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -236,6 +236,15 @@ To remove an existing keyboard shortcut, you can use `keymap.unbind()`.
     Afterwards, press the "Save" button to save the changes.
     ![Screenshot showing the keybind changer][13]{ loading=lazy }
 
+### X11: Remapping CapsLock and Ctrl
+
+Lite-XL reads scancodes from SDL so it's not aware of any remapping done via X11 (e.g. via `xkbset` or GNOME settings).
+The tool `setscancodes` can be used as a workaround. A common use case is to map CapsLock to an additional Ctrl:
+
+```bash
+sudo setkeycodes 3a 29
+```
+
 ## Themes
 
 The default theme is a dark theme.


### PR DESCRIPTION
Lite-XL does not seem to be aware of any keyboard re-mapping done via the usual tools (such as `xkbset` or the GNOME settings UI). I assume this is because Lite is built on SDL, which is getting its keyboard input via some mechanism that is bypassing the usual X11 drudgery?

Anywhoo, as a lifelong Caps -> Ctrl remapper this is kind of a big deal. Fortunately there's a pretty straightforward workaround. This is a big enough deal that I think it'll cause a lot of people to bounce off Lite-XL pretty quickly.

I'm not sure this is the best place in the docs but I think it's worth documenting *somewhere*. Happy to move locations or change wording as suggested.