### PR TITLE
fixing on_keypress syntax

### DIFF
--- a/docs/developer-guide/commands-and-shortcuts/managing-keyboard-shortcuts.md
+++ b/docs/developer-guide/commands-and-shortcuts/managing-keyboard-shortcuts.md
@@ -156,8 +156,8 @@ local keymap = require "core.keymap"
 -- a simple function that logs your keypresses
 local keymap_on_key_pressed = keymap.on_key_pressed
 function keymap.on_key_pressed(key, ...)
-  local handled = keymap_on_key_pressed(self, key, ...)
   print(key, "Pressed!")
+  return keymap_on_key_pressed(key, ...)
 end
 
 local ime = require "core.ime"
@@ -170,8 +170,8 @@ function keymap.on_key_pressed(key, ...)
   -- on Linux this behavior is not observed so it can
   -- be skipped
   if PLATFORM ~= "Linux" and ime.editing then return false end
-  local handled = keymap_on_key_pressed(self, key, ...)
   print(key, "Pressed!")
+  return keymap_on_key_pressed(key, ...)
 end
 ```
 

--- a/docs/developer-guide/commands-and-shortcuts/managing-keyboard-shortcuts.md
+++ b/docs/developer-guide/commands-and-shortcuts/managing-keyboard-shortcuts.md
@@ -156,8 +156,8 @@ local keymap = require "core.keymap"
 -- a simple function that logs your keypresses
 local keymap_on_key_pressed = keymap.on_key_pressed
 function keymap.on_key_pressed(key, ...)
+  local handled = keymap_on_key_pressed(key, ...)
   print(key, "Pressed!")
-  return keymap_on_key_pressed(key, ...)
 end
 
 local ime = require "core.ime"
@@ -170,8 +170,8 @@ function keymap.on_key_pressed(key, ...)
   -- on Linux this behavior is not observed so it can
   -- be skipped
   if PLATFORM ~= "Linux" and ime.editing then return false end
+  local handled = keymap_on_key_pressed(key, ...)
   print(key, "Pressed!")
-  return keymap_on_key_pressed(key, ...)
 end
 ```
 


### PR DESCRIPTION
Hey ! 

This pull request corrects the override examples of keymap.on_key_pressed in the developer documentation. Previously, the code incorrectly passed self as the first argument to keymap_on_key_pressed, which does not match the actual function signature. The updated examples now correctly pass only key and any additional arguments, ensuring the sample code aligns with the intended API usage.